### PR TITLE
Fix race condition when writing concurrent messages; Table creation performed once per session;

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Connector to Azure Table Storage on Node-Red",
   "version": "0.1.5",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.4.6"
   },
      "dependencies" : { 
          "azure-storage" : "^1.0.0" 


### PR DESCRIPTION
The current code has an issue where if multiple messages arrive and are written in a short burst (usually an outcome of splitting an array of items to be written into constituent messages), only the last message of the sequence ends up getting written out with the rest of the messages failing to save. The error message presented is: the Partition and RowKey combination already exist. This behaviour is due to storing message pointer in the module-scoped entityClass variable and the use of the createTableIfNotExist method providing a random delay. By the time all createTableIfNotExist callbacks are called and ready to proceed to insertEntity call, the entityClass class variable of all invocations points to the last message of the message sequence, resulting in multiple writes of the same message. The only way the code works for multiple messages as is, is by introducing a Delay node in the rate limiting mode of around 1 message per 2 seconds, allowing all callbacks to resolve properly for a single message before the Azure Table node accepts the next one.

Please kindly accept this PR to resolve the issue. I also added an optimization that invokes the createTableIfNotExist only once per table within the same node-red runtime session. 